### PR TITLE
Fix: 결과 뷰 에러 후 재시도할 때 오류 Alert 안 닫히는 문제 수정

### DIFF
--- a/Afterschool/Afterschool/Presentation/Common/Components/Error/ErrorAlert.swift
+++ b/Afterschool/Afterschool/Presentation/Common/Components/Error/ErrorAlert.swift
@@ -63,7 +63,7 @@ struct ErrorAlertModifier: ViewModifier {
                         
                         ErrorAlert(title: title, buttonTitle: buttonTitle) {
                             action()
-                            isPresented.toggle() // 액션 수행 후 창을 닫는다
+                            isPresented = false // 액션 수행 후 창을 닫는다
                         }
                         .padding(.horizontal, 16)
                         

--- a/Afterschool/Afterschool/Presentation/Result/LoadingAndResultViewModel.swift
+++ b/Afterschool/Afterschool/Presentation/Result/LoadingAndResultViewModel.swift
@@ -86,12 +86,15 @@ extension LoadingAndResultViewModel {
                 
                 skipMenus.append(recommendation)
                 
-                await MainActor.run {
-                    self.recommendationMenuName = recommendation
+                await MainActor.run { [weak self] in
+                    self?.recommendationMenuName = recommendation
                 }
             } catch {
                 logger.error("❌ failed to get recommendation menu: \(error)")
-                isError = true
+                
+                await MainActor.run { [weak self] in
+                    self?.isError = true
+                }
             }
         }
     }


### PR DESCRIPTION
## 📌 PR 제목
<!-- 간결하고 명확하게 작성 -->

결과 뷰 에러 후 재시도할 때 오류 Alert 안 닫히는 문제 수정

---

## 📝 개요
<!-- 변경 내용과 목적을 간략히 설명 -->
- 결과 뷰 에러 후 재시도할 때 오류 Alert 안 닫히는 문제 수정
- 분석 내용은 #45 참고

---

## 🔄 변경 사항
<!-- 주요 변경 내용 목록 -->
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 문서 업데이트
- [ ] 리팩토링
- [ ] 테스트 추가/수정

---

## ✅ 체크리스트
- [x] 코드 스타일 가이드 준수
- [x] 기존 기능 정상 동작 확인
- [ ] 새로운 기능/수정 사항에 대한 테스트 작성 및 통과
- [ ] 관련 문서 업데이트

---

## 📎 참고 사항
<!-- 연관된 이슈 번호, 참고 링크 등 -->
- Closes #45
- Related to #
