### PR TITLE
Design: Navigation Bar SafeArea 고려하여 상단의 내부 패딩을 없앰

### DIFF
--- a/Afterschool/Afterschool/Presentation/Common/Components/NavigationBar.swift
+++ b/Afterschool/Afterschool/Presentation/Common/Components/NavigationBar.swift
@@ -22,37 +22,41 @@ struct NavigationBar<CenterView>: ViewModifier where CenterView: View {
     /// MARK: - Constraints
     private let backButtonImageWidth: CGFloat = 15
     private let backButtonImageHeight: CGFloat = 21
-    private let navBarHeight: CGFloat = 76
+    private let navBarHeight: CGFloat = 60
+    private let navBarInnerBottomPadding: CGFloat = 12
     private let horizontalPadding: CGFloat = 18
     private let inversedBackgroundColor: Color = Color(hex: "545454")
     
     func body(content: Content) -> some View {
         VStack(spacing: 0) {
-            ZStack {
-                HStack { // 좌측 버튼
+            ZStack(alignment: .top) {
+                // 좌측 백 버튼
+                HStack {
                     Button {
                         dismiss()
                     } label: {
                         Image(systemName: "chevron.left")
                             .resizable()
                             .aspectRatio(contentMode: .fit)
-                            .foregroundColor(!inversed ? Color.afBlack : Color.afWhite)
+                            .foregroundStyle(!inversed ? Color.afBlack : Color.afWhite)
                             .frame(width: backButtonImageWidth, height: backButtonImageHeight)
                     }
-                    
                     Spacer()
                 }
-                .frame(height: navBarHeight)
-                .frame(maxWidth: .infinity)
+                .frame(height: navBarHeight - navBarInnerBottomPadding)
+                .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal, horizontalPadding)
                 
-                HStack { // 가운데 뷰
+                // 중앙 뷰
+                HStack {
                     Spacer()
                     centerView
-                        .frame(maxHeight: navBarHeight)
                     Spacer()
                 }
+                .frame(height: navBarHeight - navBarInnerBottomPadding)
             }
+            .frame(height: navBarHeight, alignment: .top)
+            .background(!inversed ? Color.afWhite : inversedBackgroundColor)
             .background(!inversed ? Color.afWhite : inversedBackgroundColor)
             .ignoresSafeArea(.all, edges: .horizontal)
             .ignoresSafeArea(.all, edges: .bottom)
@@ -98,7 +102,7 @@ extension UINavigationController: UIGestureRecognizerDelegate {
         navigationBar.isHidden = true
         interactivePopGestureRecognizer?.delegate = self
     }
-
+    
     public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         return viewControllers.count > 1 && !UINavigationController.isGestureDisabled
     }
@@ -117,7 +121,7 @@ extension UINavigationController: UIGestureRecognizerDelegate {
         Spacer()
     }
         .afNavigationBar(centerView: demoCenterView)
-//        .afNavigationBar(title: "학교 변경하기")
+    //        .afNavigationBar(title: "학교 변경하기")
     
     NavigationStack {
         NavigationLink("하이") {

--- a/Afterschool/Afterschool/Presentation/School/SubViews/SearchBar.swift
+++ b/Afterschool/Afterschool/Presentation/School/SubViews/SearchBar.swift
@@ -34,7 +34,7 @@ struct SearchBar: View {
             }
         }
         .padding(.horizontal, 16)
-        .padding(.vertical, 14)
+        .frame(height: 44)
         .background(Color.afGray50)
         .cornerRadius(8)
     }


### PR DESCRIPTION
## 📌 PR 제목
<!-- 간결하고 명확하게 작성 -->

Navigation Bar SafeArea 고려하여 상단의 내부 패딩을 없앰

---

## 📝 개요
<!-- 변경 내용과 목적을 간략히 설명 -->

- 하이파이 디자인에는 네비게이션 바가 Status Bar 바로 아래에 위치
- 실제로는 Status Bar 영역이 SafeArea를 침범함
- 디자이너 요시와 논의 후, 네비게이션 바의 윗 부분 간격을 삭제하고, 내부 컴포넌트를 탑을 기준으로 세로 정렬하도록 변경함

### 작업 내용

<img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/2e4e5b97-2cc6-4ab6-8ed0-3b60e936e236" />

<img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/f5df78b5-8eee-4a5b-8f40-3ae5badd017b" />


---

## 🔄 변경 사항
<!-- 주요 변경 내용 목록 -->
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 리팩토링
- [ ] 테스트 추가/수정

---

## ✅ 체크리스트
- [x] 코드 스타일 가이드 준수
- [x] 기존 기능 정상 동작 확인
- [x] 새로운 기능/수정 사항에 대한 테스트 작성 및 통과
- [x] 관련 문서 업데이트

---

## 📎 참고 사항
<!-- 연관된 이슈 번호, 참고 링크 등 -->
- Closes #67 
- Related to #
