### PR TITLE
Chore: Info.plist에 ITSAppUsesNonExemptEncryption 추가

### DIFF
--- a/Afterschool/Afterschool.xcodeproj/project.pbxproj
+++ b/Afterschool/Afterschool.xcodeproj/project.pbxproj
@@ -434,6 +434,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Afterschool/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "맛저";
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
@@ -470,6 +471,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Afterschool/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "맛저";
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;


### PR DESCRIPTION
## 📌 PR 제목
<!-- 간결하고 명확하게 작성 -->

Info.plist에 ITSAppUsesNonExemptEncryption 추가

---

## 📝 개요
<!-- 변경 내용과 목적을 간략히 설명 -->

- 앱스토어는 미국에 있고, 세계 대상으로 앱을 출시하면 미국 법 기준으로 미국 제품의 수출에 해당. 이때 앱에 암호화 기술이 포함된 경우 규제 대상
- 앱스토어 커넥트에서는 매 배포시 Info.plist에 ITSAppUsesNonExemptEncryption를 통해 암호화 기술 포함 여부가 제공되지 않으면 수동으로 개발자가 입력해주기를 요구함
- 우리 앱은 별도 암호화 기술이 적용되어 있지 않고, 추후 서버 통신을 HTTPS으로 전환할 계획은 있으나, TLS는 면제 대상이므로 `ITSAppUsesNonExemptEncryption`를 false로 지정

---

## 🔄 변경 사항
<!-- 주요 변경 내용 목록 -->
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 리팩토링
- [ ] 테스트 추가/수정

---

## ✅ 체크리스트
- [ ] 코드 스타일 가이드 준수
- [ ] 기존 기능 정상 동작 확인
- [ ] 새로운 기능/수정 사항에 대한 테스트 작성 및 통과
- [ ] 관련 문서 업데이트

---

## 📎 참고 사항
<!-- 연관된 이슈 번호, 참고 링크 등 -->
- Closes #58
- Related to #
